### PR TITLE
updated way to create react native app with expo

### DIFF
--- a/React-Native.ipynb
+++ b/React-Native.ipynb
@@ -96,7 +96,7 @@
     "source ~/zshrc\n",
     "```\n",
     "\n",
-    "Creating a New React Native Project\n",
+    "<s>Creating a New React Native Project\n",
     "```\n",
     "npx react-native init MyReactNativeApp\n",
     "```\n",
@@ -109,6 +109,12 @@
     "Running the App in iOS\n",
     "```\n",
     "npx react-native run-ios\n",
+    "```\n",
+    "</s>\n",
+    "\n",
+    "New way to create app\n",
+    "```\n",
+    "npx create-expo-app MyReactNativeApp\n",
     "```"
    ]
   },


### PR DESCRIPTION
This pull request updates the `React-Native.ipynb` file to reflect changes in how React Native projects are created and introduces a new method for app creation.

Updates to project creation instructions:

* Replaced the heading "Creating a New React Native Project" with a formatted alternative using `<s>` tags to indicate a change in the section structure. (`[React-Native.ipynbL99-R99](diffhunk://#diff-fefa7030149d3be1a5d04736811ee1dbaabf60324ab480680f553ab2edbd68b6L99-R99)`)
* Added a new method for creating apps using `npx create-expo-app MyReactNativeApp`, along with appropriate formatting and closure of the previous code block. (`[React-Native.ipynbR112-R117](diffhunk://#diff-fefa7030149d3be1a5d04736811ee1dbaabf60324ab480680f553ab2edbd68b6R112-R117)`)